### PR TITLE
Change osarch to use more-portable uname

### DIFF
--- a/endorlabs_atst/utils/osarch.py
+++ b/endorlabs_atst/utils/osarch.py
@@ -1,10 +1,11 @@
 # stdlib
-import os
+import os, platform
 
 OS_MAP = {
     'darwin': 'macos',
     'gnu/linux': 'linux',
-    'linux': 'linux'
+    'linux': 'linux',
+    'windows': 'windows'
 }
 
 ARCH_MAP = {
@@ -12,12 +13,12 @@ ARCH_MAP = {
     'x64': 'amd64',
     'aarch64': 'arm64',
     'arm64': 'arm64',
-    'amd64': 'amd64'
+    'amd64': 'amd64',
 }
 
 def get_osarch(osname=None, arch=None):
-    uname = os.uname()
-    _osname = OS_MAP.get(uname.sysname.lower(), uname.sysname.lower()) if osname is None else osname
+    uname = platform.uname()
+    _osname = OS_MAP.get(uname.system.lower(), uname.system.lower()) if osname is None else osname
     _arch = ARCH_MAP.get(uname.machine.lower(), uname.machine.lower()) if arch is None else arch
 
     return(_osname, _arch)


### PR DESCRIPTION
- Sets up for windows support for `setup`
- Uses `platform.uname()` instead of `os.uname()