### PR TITLE
Improve exception handling and interval writing

### DIFF
--- a/endorlabs_atst/cmd_setup.py
+++ b/endorlabs_atst/cmd_setup.py
@@ -17,7 +17,10 @@ from .utils.verdata import endorctl_version
 def get_endorctl_latest_data(osname:str, arch:str, endpoint:str='https://api.endorlabs.com/meta/version'):
     Status.debug(f"Getting version info from {endpoint}")
     resp = requests.get(endpoint)
-    ver_data = resp.json()
+    try:
+        ver_data = resp.json()
+    except Exception as e:
+        Status.fatal(f"Error decodig response from {endpoint}: {e}\n{resp.text}")
     Status.debug(Status.json(ver_data))
 
     ver_os = ver_data.get('Service',{}).get('Version', None)

--- a/endorlabs_atst/cmd_setup.py
+++ b/endorlabs_atst/cmd_setup.py
@@ -14,13 +14,20 @@ from .utils.commandstreamer import StreamedProcess
 from .utils.verdata import endorctl_version
 
 
-def get_endorctl_latest_data(osname:str, arch:str, endpoint:str='https://api.endorlabs.com/meta/version'):
+def get_endorctl_latest_data(osname:str, arch:str, endpoint:str='https://api.endorlabs.com/meta/version', try_count=1):
+    max_tries = 3
     Status.debug(f"Getting version info from {endpoint}")
     resp = requests.get(endpoint)
     try:
         ver_data = resp.json()
     except Exception as e:
-        Status.fatal(f"Error decodig response from {endpoint}: {e}\n{resp.text}")
+        Status.error(f"Error decodig response from {endpoint}: {e}\n{resp.text}")
+        if try_count > max_tries:
+            Status.fatal(f"After {max_tries} failures, giving up")
+        else:
+            Status.info(f"Waiting 2s and trying again ({try_count+1}/{max_tries} attempts)")
+            time.sleep(2)
+        return get_endorctl_latest_data(osname, arch, endpoint, try_count+1)
     Status.debug(Status.json(ver_data))
 
     ver_os = ver_data.get('Service',{}).get('Version', None)

--- a/endorlabs_atst/utils/ci_detection.py
+++ b/endorlabs_atst/utils/ci_detection.py
@@ -94,7 +94,9 @@ class CI_GitHub(CI_Environment):
         return self._arch
 
     def set_env(self, name:str, value:object):
-       return self._append_to_file(os.getenv('GITHUB_ENV', None), f"{name}={shlex.quote(str(value))}\n")
+        env_file = os.getenv('GITHUB_ENV', None)
+        print(f"Exporting env {name}=\"{value}\" by writing to {env_file}")
+        return self._append_to_file(os.getenv('GITHUB_ENV', None), f"{name}={shlex.quote(str(value))}\n")
 
 
 class CI_GitLab(CI_Environment):


### PR DESCRIPTION
- add a `--reprint-interval` option (default 30s) for `ctl`; this will print a message every N seconds if no STDERR output has been received. This is an "is this still working?" signal
- add retry loop and exception handling when unable to see the version endpoint/parse its response. Tries 3 times, with a 2s delay, before giving up.
- adds a debugging line to indicate when an env var is being set in GitHub; this will need to be removed before next release as it may emit sensitive data