### PR TITLE
Add `check-regex` subcommand

### DIFF
--- a/endorlabs_atst/__main__.py
+++ b/endorlabs_atst/__main__.py
@@ -3,5 +3,6 @@ import warnings
 from .main import *
 from .cmd_setup import setup
 from .cmd_ctl import ctl
+from .cmd_check_regex import check_regex
 
 warnings.filterwarnings('ignore')

--- a/endorlabs_atst/cmd_check_regex.py
+++ b/endorlabs_atst/cmd_check_regex.py
@@ -65,10 +65,12 @@ def _check_regex(ctx, exclude_pattern, include_pattern, hide_exclude, hide_inclu
 def check_regex(ctx, *args, **kwargs):
     """
     BETA - Check include/exclude regex against paths.
-    
+
     Checks children of PATH against regex patterns and prints which files will be
     included. PATH defaults to the current directory if not provided.
     
+    You must provide at least one exclude or include pattern.
+
     \b
     Output is in format `ACTION:PATH:` where ACTION is one of:
       - DEFAULT (this path is included by default)
@@ -77,4 +79,8 @@ def check_regex(ctx, *args, **kwargs):
 
     NOTE: this is an *estimation* of what endorctl will do
     """
+    if kwargs.get('exclude_pattern') is None and kwargs.get('include_pattern') is None:
+        Status.error("No patterns provided")
+        click.echo(ctx.get_help())
+        exit(1)
     _check_regex(ctx, *args, **kwargs)

--- a/endorlabs_atst/cmd_check_regex.py
+++ b/endorlabs_atst/cmd_check_regex.py
@@ -1,0 +1,80 @@
+# stdlib
+import os
+import contextlib
+# installed
+import click
+import re2
+#local
+from .main import main, Status, CI, CLICK_CONTEXT_SETTINGS
+
+
+@contextlib.contextmanager
+def dirpath(path):
+    original = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(original)
+
+
+def _check_regex(ctx, exclude_pattern, include_pattern, hide_exclude, hide_include, hide_default, path=os.path.realpath(os.getcwd())):
+    try:
+        _data = ['exclude-pattern', exclude_pattern]
+        exclude_regex = re2.compile(exclude_pattern) if exclude_pattern is not None else None
+        _data = ['include-pattern', include_pattern]
+        include_regex = re2.compile(include_pattern) if include_pattern is not None else None
+    except re2.error as err:
+        Status.fatal(f"unable to parse {_data[0]} '{_data[1]}' as valid RE2 expression: {err.args[0].decode('utf8')}")
+
+    if hide_default and hide_exclude and hide_include:
+        Status.debug("Skipping scan because all results are suppressed")
+        exit(0)  # no point in actually scanning of all results are suppressed
+
+    path = os.path.realpath(path)
+    Status.info(f"Scanning starting with '{path}' as base")
+    with dirpath(path):
+        for start_dir, dirs, files in os.walk('.'):
+            Status.debug(f"in {start_dir}; dirs: {dirs}; - files: {files}")
+            for pth in [start_dir] + [os.path.join(start_dir, p) for p in files]:
+                pth = pth[2:]
+                exclude_match = None if exclude_regex is None else exclude_regex.search(pth)
+                include_match = None if include_regex is None else include_regex.search(pth)
+
+                if exclude_match and not include_match and not hide_exclude:
+                    print(f"EXCLUDE:{pth}:")
+                elif exclude_match and include_match and not hide_include:
+                    print(f"INCLUDE:{pth}:")
+                elif not hide_default:
+                    print(f"DEFAULT:{pth}:")
+
+
+@main.command(context_settings=CLICK_CONTEXT_SETTINGS)
+@click.option('--exclude-pattern',
+    help="Pattern to exclude in format passed to endorctl --exclude")
+@click.option('--include-pattern',
+    help="Pattern to include in format passed to endorctl --include")
+@click.option('--hide-exclude', is_flag=True,
+    help="Don't print EXCLUDE lines")
+@click.option('--hide-include', is_flag=True,
+    help="Don't print INCLUDE lines")
+@click.option('--hide-default', is_flag=True,
+    help="Don't print DEFAULT lines")
+@click.argument('path', default=os.path.realpath(os.getcwd()))
+@click.pass_context
+def check_regex(ctx, *args, **kwargs):
+    """
+    BETA - Check include/exclude regex against paths.
+    
+    Checks children of PATH against regex patterns and prints which files will be
+    included. PATH defaults to the current directory if not provided.
+    
+    \b
+    Output is in format `ACTION:PATH:` where ACTION is one of:
+      - DEFAULT (this path is included by default)
+      - INCLUDE (this path would have been excluded, but the include pattern overrides)
+      - EXCLUDE (this path is excluded)
+
+    NOTE: this is an *estimation* of what endorctl will do
+    """
+    _check_regex(ctx, *args, **kwargs)

--- a/endorlabs_atst/main.py
+++ b/endorlabs_atst/main.py
@@ -16,16 +16,18 @@ Status = StatusWriter()
 CI = detected_CI()
 
 @click.group(context_settings=CLICK_CONTEXT_SETTINGS)
+@click.option('--debug', is_flag=True, hidden=True,
+    default=os.getenv('DEBUG', False) or os.getenv(f'{CONFIG_PREFIX}_DEBUG', False))
 @click.pass_context
-def main(ctx):
+def main(ctx, debug):
     ctx.ensure_object(dict)
     ctx.obj['script'] = os.path.abspath(sys.argv[0])
     ctx.obj['scriptdir'] = os.path.dirname(ctx.obj['script'])
     ctx.obj['ci'] = CI
-    if os.getenv('DEBUG', False) or os.getenv(f'{CONFIG_PREFIX}_DEBUG', False):
+    if debug:
         Status.loglevel = Status.DEBUG
     
-    Status.info(f"Starting {ctx.info_name} {__package_version} from {ctx.obj['script']}")
+    Status.info(f"Starting {ctx.info_name} {__package_version}" +  (f" from {ctx.obj['script']}" if debug else ''))
     Status.debug(f"CI type is {type(CI)}, named '{CI.name}'")
     Status.debug(f"Repo working directory is '{CI.repo_dir}'")
     Status.info(f"Running in {CI.name}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ requires-python = ">=3.9"
 dependencies = [
     "click~=8.1",
     "requests~=2.31",
-    "semantic-version~=2.10" 
+    "semantic-version~=2.10",
+    "google-re2~=1.1"
 ]
 
 [project.urls]


### PR DESCRIPTION
Assistant to check to see what paths your include/exclude regexes will match, to make debugging `endorctl scan --exclude REGEX --include REGEX` commands easier.
